### PR TITLE
Add support for non-conforming nullish values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,9 +44,16 @@ export function toPoint(lspPosition) {
  *   The LSP range.
  */
 export function fromPosition(unistPosition) {
+  let end = unistPosition.end
+
+  // eslint-disable-next-line eqeqeq, no-eq-null
+  if (!end || end.line == null || end.column == null) {
+    end = unistPosition.start
+  }
+
   return {
     start: fromPoint(unistPosition.start),
-    end: fromPoint(unistPosition.end)
+    end: fromPoint(end)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "remark-preset-wooorm": "^9.0.0",
     "type-coverage": "^2.0.0",
     "typescript": "^4.0.0",
-    "xo": "^0.53.0"
+    "xo": "^0.54.0"
   },
   "scripts": {
     "prepack": "npm run build && npm run format",

--- a/test/index.js
+++ b/test/index.js
@@ -39,6 +39,45 @@ test('fromPosition', async () => {
     },
     'should convert unist positions to LSP ranges'
   )
+
+  assert.deepEqual(
+    fromPosition({
+      start: {line: 1, column: 2},
+      // @ts-expect-error We test invalid user input here.
+      end: {line: null, column: 4}
+    }),
+    {
+      start: {line: 0, character: 1},
+      end: {line: 0, character: 1}
+    },
+    'should convert unist positions to LSP ranges if end line is null'
+  )
+
+  assert.deepEqual(
+    fromPosition({
+      start: {line: 1, column: 2},
+      // @ts-expect-error We test invalid user input here.
+      end: {line: 3, column: null}
+    }),
+    {
+      start: {line: 0, character: 1},
+      end: {line: 0, character: 1}
+    },
+    'should convert unist positions to LSP ranges if end line is null'
+  )
+
+  assert.deepEqual(
+    fromPosition({
+      start: {line: 1, column: 2},
+      // @ts-expect-error We test invalid user input here.
+      end: null
+    }),
+    {
+      start: {line: 0, character: 1},
+      end: {line: 0, character: 1}
+    },
+    'should convert unist positions to LSP ranges if end line is null'
+  )
 })
 
 test('toPosition', async () => {


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Some unified plugins generate such values.

<!--do not edit: pr-->
