### PR TITLE
Add `fromPlace`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,7 @@
-export {toPoint, toPosition, fromPoint, fromPosition} from './lib/index.js'
+export {
+  toPoint,
+  toPosition,
+  fromPlace,
+  fromPoint,
+  fromPosition
+} from './lib/index.js'

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 export {
-  toPoint,
-  toPosition,
   fromPlace,
   fromPoint,
-  fromPosition
+  fromPosition,
+  toPoint,
+  toPosition
 } from './lib/index.js'

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,3 +71,30 @@ export function toPosition(range) {
     end: toPoint(range.end)
   }
 }
+
+/**
+ * Convert a unist point, position, or undefined to an LSP range.
+ *
+ * @param {Readonly<UnistPosition> | Readonly<Point> | undefined} place
+ *   The unist point or position to convert.
+ *   If place is undefined, this returns an empty range at the beginning of the document.
+ * @returns {Range}
+ *   The LSP range.
+ */
+export function fromPlace(place) {
+  if (!place) {
+    return {
+      start: {line: 0, character: 0},
+      end: {line: 0, character: 0}
+    }
+  }
+
+  if ('line' in place && 'column' in place) {
+    return {
+      start: fromPoint(place),
+      end: fromPoint(place)
+    }
+  }
+
+  return fromPosition(place)
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,33 @@
  */
 
 /**
+ * Convert a unist point, position, or `undefined` to an LSP range.
+ *
+ * @param {Readonly<UnistPosition> | Readonly<Point> | undefined} place
+ *   The unist point or position to convert.
+ *   If place is `undefined`, this returns an empty range at the beginning of the document.
+ * @returns {Range}
+ *   The LSP range.
+ */
+export function fromPlace(place) {
+  if (!place) {
+    return {
+      start: {line: 0, character: 0},
+      end: {line: 0, character: 0}
+    }
+  }
+
+  if ('line' in place && 'column' in place) {
+    return {
+      start: fromPoint(place),
+      end: fromPoint(place)
+    }
+  }
+
+  return fromPosition(place)
+}
+
+/**
  * Turn a unist point into an LSP position.
  *
  * @param {Readonly<Point>} point
@@ -70,31 +97,4 @@ export function toPosition(range) {
     start: toPoint(range.start),
     end: toPoint(range.end)
   }
-}
-
-/**
- * Convert a unist point, position, or undefined to an LSP range.
- *
- * @param {Readonly<UnistPosition> | Readonly<Point> | undefined} place
- *   The unist point or position to convert.
- *   If place is undefined, this returns an empty range at the beginning of the document.
- * @returns {Range}
- *   The LSP range.
- */
-export function fromPlace(place) {
-  if (!place) {
-    return {
-      start: {line: 0, character: 0},
-      end: {line: 0, character: 0}
-    }
-  }
-
-  if ('line' in place && 'column' in place) {
-    return {
-      start: fromPoint(place),
-      end: fromPoint(place)
-    }
-  }
-
-  return fromPosition(place)
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,22 +6,14 @@
  */
 
 /**
- * Convert a unist point, position, or `undefined` to an LSP range.
+ * Convert a unist point or position to an LSP range.
  *
- * @param {Readonly<UnistPosition> | Readonly<Point> | undefined} place
+ * @param {Readonly<UnistPosition> | Readonly<Point>} place
  *   The unist point or position to convert.
- *   If place is `undefined`, this returns an empty range at the beginning of the document.
  * @returns {Range}
  *   The LSP range.
  */
 export function fromPlace(place) {
-  if (!place) {
-    return {
-      start: {line: 0, character: 0},
-      end: {line: 0, character: 0}
-    }
-  }
-
   if ('line' in place && 'column' in place) {
     return {
       start: fromPoint(place),

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@
     *   [`fromPosition(unistPosition)`](#frompositionunistposition)
     *   [`toPoint(lspPosition)`](#topointlspposition)
     *   [`toPosition(range)`](#topositionrange)
+    *   [`fromPlace(place)`](#fromplaceplace)
 *   [Types](#types)
 *   [Compatibility](#compatibility)
 *   [Security](#security)
@@ -170,6 +171,21 @@ Convert an LSP range to a unist position.
 ###### Returns
 
 The range converted to a unist position ([`UnistPosition`][unist-position]).
+
+### `fromPlace(place)`
+
+Convert a unist point, position, or undefined to an LSP range.
+
+###### Parameters
+
+*   `place` ([UnistPoint][point] | [`UnistPosition`][unist-position] | `undefined`)
+    — the unist point or position to convert.
+    If place is undefined, this returns an empty range at the beginning of the
+    document.
+
+###### Returns
+
+The LSP range ([`Range`][range]).
 
 ## Types
 

--- a/readme.md
+++ b/readme.md
@@ -125,6 +125,8 @@ console.log(startRange)
 { start: { column: 1, line: 1 }, end: { column: 1, line: 2 } }
 { character: 0, line: 0 }
 { column: 1, line: 1 }
+{ start: { character: 0, line: 0 }, end: { character: 0, line: 1 } }
+{ start: { character: 0, line: 0 }, end: { character: 0, line: 0 } }
 ```
 
 ## API

--- a/readme.md
+++ b/readme.md
@@ -18,11 +18,11 @@
 *   [Install](#install)
 *   [Use](#use)
 *   [API](#api)
+    *   [`fromPlace(place)`](#fromplaceplace)
     *   [`fromPoint(point)`](#frompointpoint)
     *   [`fromPosition(unistPosition)`](#frompositionunistposition)
     *   [`toPoint(lspPosition)`](#topointlspposition)
     *   [`toPosition(range)`](#topositionrange)
-    *   [`fromPlace(place)`](#fromplaceplace)
 *   [Types](#types)
 *   [Compatibility](#compatibility)
 *   [Security](#security)
@@ -76,7 +76,13 @@ Say we have the following `example.md`:
 ```js
 import fs from 'node:fs/promises'
 import {fromMarkdown} from 'mdast-util-from-markdown'
-import {fromPoint, fromPosition, toPoint, toPosition} from 'unist-util-lsp'
+import {
+  fromPlace,
+  fromPoint,
+  fromPosition,
+  toPoint,
+  toPosition
+} from 'unist-util-lsp'
 
 const markdown = String(await fs.readFile('example.md'))
 const mdast = fromMarkdown(markdown)
@@ -98,6 +104,14 @@ console.log(startPosition)
 const startPoint = toPoint(startPosition)
 
 console.log(startPoint)
+
+const fullRange = fromPlace(mdast.position)
+
+console.log(fullRange)
+
+const startRange = fromPlace(mdast.position.start)
+
+console.log(startRange)
 ```
 
 …now running `node example.js` yields:
@@ -115,10 +129,25 @@ console.log(startPoint)
 
 ## API
 
-This package exports the identifiers [`fromPoint`][api-from-point],
-[`fromPosition`][api-from-position], [`toPoint`][api-to-point],
-and [`toPosition`][api-to-position].
+This package exports the identifiers [`fromPlace`][api-from-place],
+[`fromPoint`][api-from-point], [`fromPosition`][api-from-position],
+[`toPoint`][api-to-point], and [`toPosition`][api-to-position].
 There is no default export.
+
+### `fromPlace(place)`
+
+Convert a unist point, position, or undefined to an LSP range.
+
+###### Parameters
+
+*   `place` ([UnistPoint][point] | [`UnistPosition`][unist-position] | `undefined`)
+    — the unist point or position to convert.
+    If place is undefined, this returns an empty range at the beginning of the
+    document.
+
+###### Returns
+
+The LSP range ([`Range`][range]).
 
 ### `fromPoint(point)`
 
@@ -171,21 +200,6 @@ Convert an LSP range to a unist position.
 ###### Returns
 
 The range converted to a unist position ([`UnistPosition`][unist-position]).
-
-### `fromPlace(place)`
-
-Convert a unist point, position, or undefined to an LSP range.
-
-###### Parameters
-
-*   `place` ([UnistPoint][point] | [`UnistPosition`][unist-position] | `undefined`)
-    — the unist point or position to convert.
-    If place is undefined, this returns an empty range at the beginning of the
-    document.
-
-###### Returns
-
-The LSP range ([`Range`][range]).
 
 ## Types
 
@@ -284,6 +298,8 @@ abide by its terms.
 [lsp-position]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#position
 
 [range]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#range
+
+[api-from-place]: #fromplaceplace
 
 [api-from-point]: #frompointpoint
 

--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,7 @@ Convert a unist point or position to an LSP range.
 ###### Parameters
 
 *   `place` ([UnistPoint][point] | [`UnistPosition`][unist-position])
-    — the unist point or position to convert.
+    — the unist point or position to convert
 
 ###### Returns
 

--- a/readme.md
+++ b/readme.md
@@ -138,14 +138,12 @@ There is no default export.
 
 ### `fromPlace(place)`
 
-Convert a unist point, position, or undefined to an LSP range.
+Convert a unist point or position to an LSP range.
 
 ###### Parameters
 
-*   `place` ([UnistPoint][point] | [`UnistPosition`][unist-position] | `undefined`)
+*   `place` ([UnistPoint][point] | [`UnistPosition`][unist-position])
     — the unist point or position to convert.
-    If place is undefined, this returns an empty range at the beginning of the
-    document.
 
 ###### Returns
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,17 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import {fromPoint, fromPosition, toPoint, toPosition} from 'unist-util-lsp'
+import {
+  fromPlace,
+  fromPoint,
+  fromPosition,
+  toPoint,
+  toPosition
+} from 'unist-util-lsp'
 
 test('unist-util-lsp', async function (t) {
   await t.test('should expose the public api', async function () {
     assert.deepEqual(Object.keys(await import('unist-util-lsp')).sort(), [
+      'fromPlace',
       'fromPoint',
       'fromPosition',
       'toPoint',
@@ -119,6 +126,37 @@ test('toPosition', async function (t) {
           end: {line: 2, character: 3}
         }),
         {start: {line: 1, column: 2}, end: {line: 3, column: 4}}
+      )
+    }
+  )
+})
+
+test('fromPlace', async function (t) {
+  await t.test(
+    'should convert undefined to an empty range at position 0',
+    async function () {
+      assert.deepEqual(fromPlace(undefined), {
+        start: {line: 0, character: 0},
+        end: {line: 0, character: 0}
+      })
+    }
+  )
+  await t.test(
+    'should convert unist points to LSP positions',
+    async function () {
+      assert.deepEqual(fromPlace({line: 43, column: 100}), {
+        start: {line: 42, character: 99},
+        end: {line: 42, character: 99}
+      })
+    }
+  )
+
+  await t.test(
+    'should convert unist positions to LSP ranges',
+    async function () {
+      assert.deepEqual(
+        fromPlace({start: {line: 1, column: 2}, end: {line: 3, column: 4}}),
+        {start: {line: 0, character: 1}, end: {line: 2, character: 3}}
       )
     }
   )

--- a/test/index.js
+++ b/test/index.js
@@ -22,15 +22,6 @@ test('unist-util-lsp', async function (t) {
 
 test('fromPlace', async function (t) {
   await t.test(
-    'should convert undefined to an empty range at position 0',
-    async function () {
-      assert.deepEqual(fromPlace(undefined), {
-        start: {line: 0, character: 0},
-        end: {line: 0, character: 0}
-      })
-    }
-  )
-  await t.test(
     'should convert unist points to LSP positions',
     async function () {
       assert.deepEqual(fromPlace({line: 43, column: 100}), {

--- a/test/index.js
+++ b/test/index.js
@@ -20,6 +20,37 @@ test('unist-util-lsp', async function (t) {
   })
 })
 
+test('fromPlace', async function (t) {
+  await t.test(
+    'should convert undefined to an empty range at position 0',
+    async function () {
+      assert.deepEqual(fromPlace(undefined), {
+        start: {line: 0, character: 0},
+        end: {line: 0, character: 0}
+      })
+    }
+  )
+  await t.test(
+    'should convert unist points to LSP positions',
+    async function () {
+      assert.deepEqual(fromPlace({line: 43, column: 100}), {
+        start: {line: 42, character: 99},
+        end: {line: 42, character: 99}
+      })
+    }
+  )
+
+  await t.test(
+    'should convert unist positions to LSP ranges',
+    async function () {
+      assert.deepEqual(
+        fromPlace({start: {line: 1, column: 2}, end: {line: 3, column: 4}}),
+        {start: {line: 0, character: 1}, end: {line: 2, character: 3}}
+      )
+    }
+  )
+})
+
 test('fromPoint', async function (t) {
   await t.test(
     'should convert unist points to LSP positions',
@@ -126,37 +157,6 @@ test('toPosition', async function (t) {
           end: {line: 2, character: 3}
         }),
         {start: {line: 1, column: 2}, end: {line: 3, column: 4}}
-      )
-    }
-  )
-})
-
-test('fromPlace', async function (t) {
-  await t.test(
-    'should convert undefined to an empty range at position 0',
-    async function () {
-      assert.deepEqual(fromPlace(undefined), {
-        start: {line: 0, character: 0},
-        end: {line: 0, character: 0}
-      })
-    }
-  )
-  await t.test(
-    'should convert unist points to LSP positions',
-    async function () {
-      assert.deepEqual(fromPlace({line: 43, column: 100}), {
-        start: {line: 42, character: 99},
-        end: {line: 42, character: 99}
-      })
-    }
-  )
-
-  await t.test(
-    'should convert unist positions to LSP ranges',
-    async function () {
-      assert.deepEqual(
-        fromPlace({start: {line: 1, column: 2}, end: {line: 3, column: 4}}),
-        {start: {line: 0, character: 1}, end: {line: 2, character: 3}}
       )
     }
   )


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This converts a unist place to an LSP range, where a unist place is a position, point, or undefined.

Based on https://github.com/unifiedjs/unified-language-server/pull/57#discussion_r1299171578

<!--do not edit: pr-->
